### PR TITLE
Usecases domain logic

### DIFF
--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -1,7 +1,12 @@
 //App Router
 export 'router/app_router.dart';
 export 'router/app_router_constants.dart';
+
 //App Theme
 export 'theme/app_theme.dart';
+
 //constants
 export 'constanst/app_assets.dart';
+
+// error handling
+export 'error/error_item.dart';

--- a/lib/core/error/error_item.dart
+++ b/lib/core/error/error_item.dart
@@ -1,0 +1,9 @@
+class ErrorItem implements Exception {
+  final String code;
+  final String message;
+
+  ErrorItem({required this.code, required this.message});
+
+  @override
+  String toString() => 'ErrorItem(code: $code, message: $message)';
+}

--- a/lib/domain/data/breed_datasource.dart
+++ b/lib/domain/data/breed_datasource.dart
@@ -1,0 +1,11 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+abstract class BreedDatasource {
+  Future<Either<ErrorItem, List<Breed>>> getBreeds();
+  Future<Either<ErrorItem, List<Breed>>> searchBreeds(String query);
+  Future<Either<ErrorItem, void>> toggleFavorite(Breed breed);
+  Future<Either<ErrorItem, List<Breed>>> getFavoriteBreeds();
+  Future<Either<ErrorItem, Breed>> getBreedDetail(int id);
+}

--- a/lib/domain/domain.dart
+++ b/lib/domain/domain.dart
@@ -1,0 +1,16 @@
+// entities
+export 'entites/breed.dart';
+export 'entites/measurement.dart';
+
+// repositories
+export 'repo/breed_repository.dart';
+
+// Datasource
+export 'data/breed_datasource.dart';
+
+// use cases
+export 'use_cases/get_breeds.dart';
+export 'use_cases/get_favorite_breeds.dart';
+export 'use_cases/get_breed_detail.dart';
+export 'use_cases/search_breeds.dart';
+export 'use_cases/toggle_favorite_breed.dart';

--- a/lib/domain/entites/breed.dart
+++ b/lib/domain/entites/breed.dart
@@ -1,0 +1,33 @@
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class Breed {
+  Measurement weight;
+  Measurement height;
+  int id;
+  String name;
+  String? bredFor;
+  String? breedGroup;
+  String lifeSpan;
+  String temperament;
+  String? origin;
+  String referenceImageId;
+  String? countryCode;
+  String? description;
+  String? history;
+
+  Breed({
+    required this.weight,
+    required this.height,
+    required this.id,
+    required this.name,
+    this.bredFor,
+    this.breedGroup,
+    required this.lifeSpan,
+    required this.temperament,
+    this.origin,
+    required this.referenceImageId,
+    this.countryCode,
+    this.description,
+    this.history,
+  });
+}

--- a/lib/domain/entites/measurement.dart
+++ b/lib/domain/entites/measurement.dart
@@ -1,0 +1,19 @@
+class Measurement {
+  String imperial;
+  String metric;
+
+  Measurement({
+    required this.imperial,
+    required this.metric,
+  });
+
+  factory Measurement.fromJson(Map<String, dynamic> json) => Measurement(
+    imperial: json["imperial"],
+    metric: json["metric"],
+  );
+
+  Map<String, dynamic> toJson() => {
+    "imperial": imperial,
+    "metric": metric,
+  };
+}

--- a/lib/domain/repo/breed_repository.dart
+++ b/lib/domain/repo/breed_repository.dart
@@ -1,0 +1,11 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+abstract class BreedRepository {
+  Future<Either<ErrorItem, List<Breed>>> getBreeds();
+  Future<Either<ErrorItem, List<Breed>>> searchBreeds(String query);
+  Future<Either<ErrorItem, void>> toggleFavorite(Breed breed);
+  Future<Either<ErrorItem, List<Breed>>> getFavoriteBreeds();
+  Future<Either<ErrorItem, Breed>> getBreedDetail(int id);
+}

--- a/lib/domain/use_cases/get_breed_detail.dart
+++ b/lib/domain/use_cases/get_breed_detail.dart
@@ -1,0 +1,12 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class GetBreedDetail {
+  final BreedRepository repository;
+  GetBreedDetail(this.repository);
+
+  Future<Either<ErrorItem, Breed>> call(int id) async {
+    return await repository.getBreedDetail(id);
+  }
+}

--- a/lib/domain/use_cases/get_breeds.dart
+++ b/lib/domain/use_cases/get_breeds.dart
@@ -1,0 +1,12 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class GetBreeds {
+  final BreedRepository repository;
+  GetBreeds(this.repository);
+
+  Future<Either<ErrorItem, List<Breed>>> call() async {
+    return await repository.getBreeds();
+  }
+}

--- a/lib/domain/use_cases/get_favorite_breeds.dart
+++ b/lib/domain/use_cases/get_favorite_breeds.dart
@@ -1,0 +1,13 @@
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:dart_either/dart_either.dart';
+
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class GetFavoriteBreeds {
+  final BreedRepository repository;
+  GetFavoriteBreeds(this.repository);
+
+  Future<Either<ErrorItem, List<Breed>>> call() async {
+    return await repository.getFavoriteBreeds();
+  }
+}

--- a/lib/domain/use_cases/search_breeds.dart
+++ b/lib/domain/use_cases/search_breeds.dart
@@ -1,0 +1,12 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class SearchBreeds {
+  final BreedRepository repository;
+  SearchBreeds(this.repository);
+
+  Future<Either<ErrorItem, List<Breed>>> call(String query) async {
+    return await repository.searchBreeds(query);
+  }
+}

--- a/lib/domain/use_cases/toggle_favorite_breed.dart
+++ b/lib/domain/use_cases/toggle_favorite_breed.dart
@@ -1,0 +1,12 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class ToggleFavoriteBreed {
+  final BreedRepository repository;
+  ToggleFavoriteBreed(this.repository);
+
+  Future<Either<ErrorItem, void>> call(Breed breed) async {
+    return await repository.toggleFavorite(breed);
+  }
+}

--- a/lib/infrastructure/data/breed_datasource_apidog.dart
+++ b/lib/infrastructure/data/breed_datasource_apidog.dart
@@ -1,0 +1,35 @@
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class BreedDatasourceApidog implements BreedDatasource {
+  @override
+  Future<Either<ErrorItem, Breed>> getBreedDetail(int id) {
+    // TODO: implement getBreedDetail
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> getBreeds() {
+    // TODO: implement getBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> getFavoriteBreeds() {
+    // TODO: implement getFavoriteBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> searchBreeds(String query) {
+    // TODO: implement searchBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, void>> toggleFavorite(Breed breed) {
+    // TODO: implement toggleFavorite
+    throw UnimplementedError();
+  }
+}

--- a/lib/infrastructure/mappers/breed_mapper.dart
+++ b/lib/infrastructure/mappers/breed_mapper.dart
@@ -1,0 +1,35 @@
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class BreedMapper {
+  static Breed fromJson(Map<String, dynamic> json) => Breed(
+    weight: Measurement.fromJson(json["weight"]),
+    height: Measurement.fromJson(json["height"]),
+    id: json["id"],
+    name: json["name"],
+    bredFor: json["bred_for"],
+    breedGroup: json["breed_group"],
+    lifeSpan: json["life_span"],
+    temperament: json["temperament"],
+    origin: json["origin"],
+    referenceImageId: json["reference_image_id"],
+    countryCode: json["country_code"],
+    description: json["description"],
+    history: json["history"],
+  );
+
+  static Map<String, dynamic> toJson(Breed breed) => {
+    "weight": breed.weight.toJson(),
+    "height": breed.height.toJson(),
+    "id": breed.id,
+    "name": breed.name,
+    "bred_for": breed.bredFor,
+    "breed_group": breed.breedGroup,
+    "life_span": breed.lifeSpan,
+    "temperament": breed.temperament,
+    "origin": breed.origin,
+    "reference_image_id": breed.referenceImageId,
+    "country_code": breed.countryCode,
+    "description": breed.description,
+    "history": breed.history,
+  };
+}

--- a/lib/infrastructure/repo/breed_repository_impl.dart
+++ b/lib/infrastructure/repo/breed_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'package:app_tecnica_pets_api/core/core.dart';
+import 'package:dart_either/dart_either.dart';
+import 'package:app_tecnica_pets_api/domain/domain.dart';
+
+class BreedRepositoryImpl implements BreedRepository {
+  final BreedDatasource datasource;
+
+  BreedRepositoryImpl(this.datasource);
+
+  @override
+  Future<Either<ErrorItem, Breed>> getBreedDetail(int id) {
+    // TODO: implement getBreedDetail
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> getBreeds() {
+    // TODO: implement getBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> getFavoriteBreeds() {
+    // TODO: implement getFavoriteBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, List<Breed>>> searchBreeds(String query) {
+    // TODO: implement searchBreeds
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Either<ErrorItem, void>> toggleFavorite(Breed breed) {
+    // TODO: implement toggleFavorite
+    throw UnimplementedError();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   characters:
     dependency: transitive
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_either:
+    dependency: "direct main"
+    description:
+      name: dart_either
+      sha256: "2c6f9bb4426c2f9e5109ca72e132e9d4f858167f9750dabd24a30c992c90db78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   dio:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.8
+  dart_either: ^2.0.0
   dio: ^5.9.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
##  Descripción
Este PR agrega la lógica de negocio del aplicativo, siguiendo una estructura de Clean Architecture.  
Incluye los casos de uso principales para manejar las razas, la búsqueda, los favoritos y el detalle de cada raza.  

---

##  Cambios principales
- Implementación de la capa de dominio con los casos de uso.
- Lógica para consultar razas y buscarlas por nombre.
- Manejo de razas favoritas.
- Lógica para mostrar el detalle de cada raza (información extendida) detalles.
- Configuración inicial para enlazar la lógica de negocio con la presentación.  
